### PR TITLE
Changing remap_annotations_with_ec2go method spec to use genome viewe…

### DIFF
--- a/ui/narrative/methods/remap_annotations_with_ec2go/spec.json
+++ b/ui/narrative/methods/remap_annotations_with_ec2go/spec.json
@@ -8,7 +8,7 @@
     "categories": ["active"],
     "widgets": {
         "input": null,
-        "output": "kbaseReportView"
+        "output": "kbaseGenomeView"
     },
     "parameters": [
         {
@@ -70,6 +70,14 @@
 		}
             ],
             "output_mapping": [
+                {
+                    "narrative_system_variable": "workspace",
+                    "target_property": "ws"
+                },
+                {
+                    "input_parameter": "output_genome",
+          	    "target_property": "id"
+                },
                 {
                     "service_method_output_path": [0,"report_name"],
                     "target_property": "report_name"


### PR DESCRIPTION
…r as output widget

Changing remap_annotations_with_ec2go method spec to use genome viewer as output widget
