### PR TITLE
Udating uniprot2go spec to use genome viewer as output widget

### DIFF
--- a/ui/narrative/methods/remap_annotations_with_uniprotkb_keyword2go/spec.json
+++ b/ui/narrative/methods/remap_annotations_with_uniprotkb_keyword2go/spec.json
@@ -8,7 +8,7 @@
     "categories": ["active"],
     "widgets": {
         "input": null,
-        "output": "kbaseReportView"
+        "output": "kbaseGenomeView"
     },
     "parameters": [
         {
@@ -52,6 +52,14 @@
             "name": "ElectronicAnnotationMethods",
             "method": "remap_annotations_with_uniprotkb_keyword2go",
             "input_mapping": [
+                {
+                    "narrative_system_variable": "workspace",
+                    "target_property": "ws"
+                },
+                {
+                    "input_parameter": "output_genome",
+          	    "target_property": "id"
+                },
                 {
                     "narrative_system_variable": "workspace",
                     "target_property": "workspace"


### PR DESCRIPTION
Udating uniprot2go spec to use genome viewer as output widget
